### PR TITLE
Use htmlspecialchars instead of utf8_encode String

### DIFF
--- a/src/POData/ObjectModel/ObjectModelSerializer.php
+++ b/src/POData/ObjectModel/ObjectModelSerializer.php
@@ -844,7 +844,8 @@ class ObjectModelSerializer extends ObjectModelSerializerBase
 	} else if ($type instanceof DateTime && $primitiveValue instanceOf \DateTime) {
             $stringValue = $primitiveValue->format(\DateTime::ATOM);
         } else if ($type instanceof String) {
-            $stringValue = utf8_encode($primitiveValue);
+            $stringValue = htmlspecialchars($primitiveValue, NULL, 'UTF-8'); // utf8_encode($primitiveValue) was troubling ascent chars.
+	    $stringValue = str_replace('&amp;', '&', $stringValue); // special exception to allow (Name & Value) be retained.
         } else {        
             $stringValue = strval($primitiveValue);
         }


### PR DESCRIPTION
To preserve UTF-8 ascent chars intact htmlspecialchars should be used instead of utf8_encode.